### PR TITLE
feat: add mcp() hook with mysql-mcp-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@
 
 ## Summary
 
-TODO: Add a short summary of this module.
+p6df module for MySQL: CLI tools (`mycli`, `percona-toolkit`, `mysqltuner`),
+prompt integration, and MCP server (`mysql-mcp-server` via npm) for
+AI-driven database querying and schema exploration.
 
 ## Contributing
 
@@ -40,8 +42,9 @@ TODO: Add a short summary of this module.
 - `p6df::modules::mysql::home::symlink()`
 - `p6df::modules::mysql::init(_module, dir)`
   - Args:
-    - _module - 
-    - dir - 
+    - _module
+    - dir
+- `p6df::modules::mysql::mcp()`
 
 #### p6df-mysql/lib
 

--- a/init.zsh
+++ b/init.zsh
@@ -77,3 +77,17 @@ p6df::modules::mysql::init() {
 
   p6_return_void
 }
+
+######################################################################
+#<
+#
+# Function: p6df::modules::mysql::mcp()
+#
+#>
+######################################################################
+p6df::modules::mysql::mcp() {
+
+  p6_js_npm_global_install "mysql-mcp-server"
+
+  p6_return_void
+}


### PR DESCRIPTION
## Summary
- Adds `p6df::modules::mysql::mcp()` installing `mysql-mcp-server` via npm
- Regenerated README with updated function list and Summary

## Test plan
- [ ] `p6df::modules::mysql::mcp()` installs `mysql-mcp-server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)