### PR TITLE
chore: replace brew services start with p6df::core::homebrew::cmd::brew

### DIFF
--- a/lib/cli.sh
+++ b/lib/cli.sh
@@ -8,5 +8,5 @@
 ######################################################################
 p6df::modules::mysql::cli::start() {
 
-  brew services start percona-server
+  p6df::core::homebrew::cmd::brew services start percona-server
 }


### PR DESCRIPTION
## Summary

- Replace `brew services start percona-server` with `p6df::core::homebrew::cmd::brew services start percona-server` in `lib/cli.sh:11`

## Test plan

- [ ] `p6df::modules::mysql::cli::start` starts percona-server correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)