### PR TITLE
fix(prompt): split p6_return_words word and variable into separate args

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -102,6 +102,6 @@ p6df::modules::mysql::mcp() {
 ######################################################################
 p6df::modules::mysql::profile::mod() {
 
-  p6_return_words 'mysql' '$MYSQL_HOST'
+  p6_return_words 'mysql' "$"
 }
 

--- a/init.zsh
+++ b/init.zsh
@@ -58,21 +58,15 @@ p6df::modules::mysql::home::symlinks() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::mysql::init(_module, dir)
-#
-#  Args:
-#	_module -
-#	dir -
+# Function: p6df::modules::mysql::env::init()
 #
 #  Environment:	 MYSQL_PS1
 #>
 ######################################################################
-p6df::modules::mysql::init() {
+p6df::modules::mysql::env::init() {
+
   local _module="$1"
-  local dir="$2"
-
-  p6_bootstrap "$dir"
-
+  local _dir="$2"
   p6_env_export MYSQL_PS1 "\v \u@\h:\p (\d)>"
 
   p6_return_void
@@ -94,3 +88,20 @@ p6df::modules::mysql::mcp() {
 
   p6_return_void
 }
+
+######################################################################
+#<
+#
+# Function: words mysql $MYSQL_HOST = p6df::modules::mysql::profile::mod()
+#
+#  Returns:
+#	words - mysql $MYSQL_HOST
+#
+#  Environment:	 MYSQL_HOST
+#>
+######################################################################
+p6df::modules::mysql::profile::mod() {
+
+  p6_return_words 'mysql' '$MYSQL_HOST'
+}
+


### PR DESCRIPTION
## What
Refactor p6df-mysql to use `p6_return_words` with word and variable as separate quoted arguments, add `profile::mod`, and rename `init` to `env::init`.

## Why
Consistent quoting convention for `p6_return_words` calls across all p6df modules.

## Test plan
- Verify `p6df::modules::mysql::profile::mod` returns two words: `mysql` and the value of `$MYSQL_HOST`
- Load module in zsh and confirm no errors

## Dependencies
None