### PR TITLE
fix(init): add MYSQL_HOST and MYSQL_HOME to profile::mod return

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -102,6 +102,6 @@ p6df::modules::mysql::mcp() {
 ######################################################################
 p6df::modules::mysql::profile::mod() {
 
-  p6_return_words 'mysql' "$"
+  p6_return_words 'mysql' '$MYSQL_HOST' '$MYSQL_HOME'
 }
 


### PR DESCRIPTION
## What
Update `p6df::modules::mysql::profile::mod()` to return actual MySQL environment variables (`$MYSQL_HOST` and `$MYSQL_HOME`) instead of the broken stub value (`"$"`).

## Why
The function was returning a malformed string. It now properly surfaces the MySQL host and home env vars for profile/prompt integration.

## Test plan
- Reviewed diff confirms `p6_return_words` now receives `'$MYSQL_HOST'` and `'$MYSQL_HOME'`

## Dependencies
None