### PR TITLE
chore(init): reorder hooks per hook_api.md lifecycle order

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,5 @@
 # shellcheck shell=bash
 ######################################################################
-#<
-#
-# Function: p6df::modules::mysql::deps()
-#
-#>
-######################################################################
 p6df::modules::mysql::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6common
@@ -13,11 +7,23 @@ p6df::modules::mysql::deps() {
 }
 
 ######################################################################
-#<
-#
-# Function: p6df::modules::mysql::external::brews()
-#
-#>
+p6df::modules::mysql::env::init() {
+
+  local _module="$1"
+  local _dir="$2"
+  p6_env_export MYSQL_PS1 "\v \u@\h:\p (\d)>"
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::mysql::home::symlinks() {
+
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-db/share/mysqlrc" "$P6_DFZ_DATA_DIR/.mysqlrc"
+
+  p6_return_void
+}
+
 ######################################################################
 p6df::modules::mysql::external::brews() {
 
@@ -41,44 +47,6 @@ p6df::modules::mysql::external::brews() {
 }
 
 ######################################################################
-#<
-#
-# Function: p6df::modules::mysql::home::symlinks()
-#
-#  Environment:	 P6_DFZ_DATA_DIR P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
-#>
-######################################################################
-p6df::modules::mysql::home::symlinks() {
-
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-db/share/mysqlrc" "$P6_DFZ_DATA_DIR/.mysqlrc"
-
-  p6_return_void
-}
-
-######################################################################
-#<
-#
-# Function: p6df::modules::mysql::env::init()
-#
-#  Environment:	 MYSQL_PS1
-#>
-######################################################################
-p6df::modules::mysql::env::init() {
-
-  local _module="$1"
-  local _dir="$2"
-  p6_env_export MYSQL_PS1 "\v \u@\h:\p (\d)>"
-
-  p6_return_void
-}
-
-######################################################################
-#<
-#
-# Function: p6df::modules::mysql::mcp()
-#
-#>
-######################################################################
 p6df::modules::mysql::mcp() {
 
   p6_js_npm_global_install "mysql-mcp-server"
@@ -90,6 +58,44 @@ p6df::modules::mysql::mcp() {
 }
 
 ######################################################################
+p6df::modules::mysql::profile::mod() {
+
+  p6_return_words 'mysql' '$MYSQL_HOST' '$MYSQL_HOME'
+}
+
+######################################################################
+#<
+#
+# Function: p6df::modules::mysql::deps()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::mysql::external::brews()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::mysql::home::symlinks()
+#
+#  Environment:	 P6_DFZ_DATA_DIR P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::mysql::env::init()
+#
+#  Environment:	 MYSQL_PS1
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::mysql::mcp()
+#
+#>
+######################################################################
 #<
 #
 # Function: words mysql $MYSQL_HOST = p6df::modules::mysql::profile::mod()
@@ -99,9 +105,3 @@ p6df::modules::mysql::mcp() {
 #
 #  Environment:	 MYSQL_HOST
 #>
-######################################################################
-p6df::modules::mysql::profile::mod() {
-
-  p6_return_words 'mysql' '$MYSQL_HOST' '$MYSQL_HOME'
-}
-

--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,24 @@
 # shellcheck shell=bash
 ######################################################################
+#<
+#
+# Function: p6df::modules::mysql::deps()
+#
+#>
+######################################################################
 p6df::modules::mysql::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6common
   )
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::mysql::env::init()
+#
+#  Environment:	 MYSQL_PS1
+#>
 ######################################################################
 p6df::modules::mysql::env::init() {
 
@@ -17,6 +30,13 @@ p6df::modules::mysql::env::init() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::mysql::home::symlinks()
+#
+#  Environment:	 P6_DFZ_DATA_DIR P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
+#>
+######################################################################
 p6df::modules::mysql::home::symlinks() {
 
   p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-db/share/mysqlrc" "$P6_DFZ_DATA_DIR/.mysqlrc"
@@ -24,6 +44,12 @@ p6df::modules::mysql::home::symlinks() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::mysql::external::brews()
+#
+#>
 ######################################################################
 p6df::modules::mysql::external::brews() {
 
@@ -47,6 +73,12 @@ p6df::modules::mysql::external::brews() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::mysql::mcp()
+#
+#>
+######################################################################
 p6df::modules::mysql::mcp() {
 
   p6_js_npm_global_install "mysql-mcp-server"
@@ -58,44 +90,6 @@ p6df::modules::mysql::mcp() {
 }
 
 ######################################################################
-p6df::modules::mysql::profile::mod() {
-
-  p6_return_words 'mysql' '$MYSQL_HOST' '$MYSQL_HOME'
-}
-
-######################################################################
-#<
-#
-# Function: p6df::modules::mysql::deps()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::mysql::external::brews()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::mysql::home::symlinks()
-#
-#  Environment:	 P6_DFZ_DATA_DIR P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::mysql::env::init()
-#
-#  Environment:	 MYSQL_PS1
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::mysql::mcp()
-#
-#>
-######################################################################
 #<
 #
 # Function: words mysql $MYSQL_HOST = p6df::modules::mysql::profile::mod()
@@ -105,3 +99,9 @@ p6df::modules::mysql::profile::mod() {
 #
 #  Environment:	 MYSQL_HOST
 #>
+######################################################################
+p6df::modules::mysql::profile::mod() {
+
+  p6_return_words 'mysql' '$MYSQL_HOST' '$MYSQL_HOME'
+}
+


### PR DESCRIPTION
## What
Reorder hook functions in `init.zsh` to match the canonical lifecycle order defined in `p6df-core/doc/hook_api.md`.

**Lifecycle:** `deps → init → env::init → path::init → cdpath::init → fpath::init → completions::init → aliases::init → langmgr::init → prompt::init`

**Install-time:** `home::symlinks → external::brews → langs → mcp → vscodes → vscodes::config`

**Profile:** `profile::on → profile::off → profile::mod → prompt::mod::bottom`

## Why
Hook functions were defined in inconsistent order across modules. Enforcing the canonical order makes the files easier to audit and ensures the documented execution sequence is visually obvious.

## Test plan
- [ ] Verified hook order with automated check (all pass)
- [ ] No functional changes — only block reordering

## Dependencies
None